### PR TITLE
 feature: add __str__ methods to queryLineage output classes

### DIFF
--- a/src/sagemaker/lineage/query.py
+++ b/src/sagemaker/lineage/query.py
@@ -92,6 +92,18 @@ class Edge:
             and self.destination_arn == other.destination_arn
         )
 
+    def __str__(self):
+        """Define string representation of ``Edge``.
+
+        Format:
+            {
+                'source_arn': 'string', 'destination_arn': 'string', 
+                'association_type': 'string'
+            }
+        
+        """
+        return (str(self.__dict__))
+
 
 class Vertex:
     """A vertex for a lineage graph."""
@@ -129,6 +141,19 @@ class Vertex:
             and self.lineage_entity == other.lineage_entity
             and self.lineage_source == other.lineage_source
         )
+
+    def __str__(self):
+        """Define string representation of ``Vertex``.
+
+        Format:
+            {
+                'arn': 'string', 'lineage_entity': 'string', 
+                'lineage_source': 'string', 
+                '_session': <sagemaker.session.Session object>
+            }
+        
+        """
+        return (str(self.__dict__))
 
     def to_lineage_object(self):
         """Convert the ``Vertex`` object to its corresponding lineage object.
@@ -198,6 +223,32 @@ class LineageQueryResult(object):
 
         if vertices is not None:
             self.vertices = vertices
+
+    def __str__(self):
+        """Define string representation of ``LineageQueryResult``.
+        
+        Format:
+        {
+            'edges':[
+                {
+                    'source_arn': 'string', 'destination_arn': 'string', 
+                    'association_type': 'string'
+                },
+                ...
+            ]
+            'vertices':[
+                {
+                    'arn': 'string', 'lineage_entity': 'string', 
+                    'lineage_source': 'string', 
+                    '_session': <sagemaker.session.Session object>
+                },
+                ...
+            ]
+        }
+        
+        """
+        result_dict = vars(self)
+        return (str({k: [vars(val) for val in v] for k, v in result_dict.items()}))
 
 
 class LineageFilter(object):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  add __str__ methods to queryLineage output classes `Edge`, `Vertex', and `LineageQueryResult` for a string representation of an instance, it will be evoked when calling print() on the object to have a more informative output

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
