### PR TITLE
documentation: add visualize & PyvisVisualizer documentation

### DIFF
--- a/src/sagemaker/lineage/query.py
+++ b/src/sagemaker/lineage/query.py
@@ -230,7 +230,31 @@ class PyvisVisualizer(object):
     """Create object used for visualizing graph using Pyvis library."""
 
     def __init__(self, graph_styles):
-        """Init for PyvisVisualizer."""
+        """Init for PyvisVisualizer.
+
+        Args:
+            graph_styles: A dictionary that contains graph style for node and edges by their type.
+                Example: Display the nodes with different color by their lineage entity / different shape by start arn.
+                        lineage_graph = {
+                            "TrialComponent": {
+                                "name": "Trial Component",
+                                "style": {"background-color": "#f6cf61"},
+                                "isShape": "False",
+                            },
+                            "Context": {
+                                "name": "Context",
+                                "style": {"background-color": "#ff9900"},
+                                "isShape": "False",
+                            },
+                            "StartArn": {
+                                "name": "StartArn",
+                                "style": {"shape": "star"},
+                                "isShape": "True",
+                                "symbol": "★",  # shape symbol for legend
+                            },
+                        }
+
+        """
         # import visualization packages
         (
             self.Network,
@@ -283,7 +307,22 @@ class PyvisVisualizer(object):
         return self.graph_styles[entity]["style"]["background-color"]
 
     def render(self, elements, path="pyvisExample.html"):
-        """Render graph for lineage query result."""
+        """Render graph for lineage query result.
+
+        Args:
+            elements: A dictionary that contains the node and the edges of the graph.
+                Example:
+                    elements["nodes"] contains a list of tuples, each tuple represents a node in the format
+                        (node arn, node lineage source, node lineage entity, node is start arn)
+                    elements["edges"] contains a list of tuples, each tuple represents an edge in the format
+                        (edge source arn, edge destination arn, edge association type)
+
+            path(optional): The path/filemname of the rendered graph html file. (default path: "pyvisExample.html")
+
+        Returns:
+            display graph: The interactive visualization is presented as a static HTML file.
+
+        """
         net = self.Network(height="500px", width="100%", notebook=True, directed=True)
         net.set_options(self._options)
 
@@ -384,7 +423,17 @@ class LineageQueryResult(object):
         return elements
 
     def visualize(self, path="pyvisExample.html"):
-        """Visualize lineage query result."""
+        """Visualize lineage query result.
+
+        Creates a PyvisVisualizer object to render network graph with Pyvis library. The elements(nodes & edges) are
+        preprocessed in this method and sent to PyvisVisualizer for rendering graph.
+
+        Args:
+            path(optional): The path/filemname of the rendered graph html file. (default path: "pyvisExample.html")
+
+        Returns:
+            display graph: The interactive visualization is presented as a static HTML file.
+        """
         lineage_graph = {
             # nodes can have shape / color
             "TrialComponent": {

--- a/src/sagemaker/lineage/query.py
+++ b/src/sagemaker/lineage/query.py
@@ -234,7 +234,8 @@ class PyvisVisualizer(object):
 
         Args:
             graph_styles: A dictionary that contains graph style for node and edges by their type.
-                Example: Display the nodes with different color by their lineage entity / different shape by start arn.
+                Example: Display the nodes with different color by their lineage entity / different
+                    shape by start arn.
                         lineage_graph = {
                             "TrialComponent": {
                                 "name": "Trial Component",
@@ -312,10 +313,11 @@ class PyvisVisualizer(object):
         Args:
             elements: A dictionary that contains the node and the edges of the graph.
                 Example:
-                    elements["nodes"] contains a list of tuples, each tuple represents a node in the format
-                        (node arn, node lineage source, node lineage entity, node is start arn)
-                    elements["edges"] contains a list of tuples, each tuple represents an edge in the format
-                        (edge source arn, edge destination arn, edge association type)
+                    elements["nodes"] contains list of tuples, each tuple represents a node
+                        format: (node arn, node lineage source, node lineage entity,
+                            node is start arn)
+                    elements["edges"] contains list of tuples, each tuple represents an edge
+                        format: (edge source arn, edge destination arn, edge association type)
 
             path(optional): The path/filemname of the rendered graph html file. (default path: "pyvisExample.html")
 
@@ -425,8 +427,10 @@ class LineageQueryResult(object):
     def visualize(self, path="pyvisExample.html"):
         """Visualize lineage query result.
 
-        Creates a PyvisVisualizer object to render network graph with Pyvis library. The elements(nodes & edges) are
-        preprocessed in this method and sent to PyvisVisualizer for rendering graph.
+        Creates a PyvisVisualizer object to render network graph with Pyvis library.
+        Pyvis library should be installed before using this method (run "pip install pyvis")
+        The elements(nodes & edges) are preprocessed in this method and sent to
+        PyvisVisualizer for rendering graph.
 
         Args:
             path(optional): The path/filemname of the rendered graph html file. (default path: "pyvisExample.html")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* documentation: add visualize & PyvisVisualizer documentation

*Testing done:*
tox -e black-format & tox -e flake8,pylint,twine,black-check,docstyle --parallel all
tox -r -e py39 tests/integ/sagemaker/lineage/test_lineage_visualize.py
tox -e py39 tests/unit/sagemaker/lineage

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
